### PR TITLE
Add `Open build path` option

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { app, BrowserWindow, dialog, ipcMain } = require('electron')
+const { app, BrowserWindow, dialog, ipcMain, shell } = require('electron')
 const path = require('path')
 import { format as formatUrl } from 'url'
 const {
@@ -207,6 +207,11 @@ ipcMain.on('write-files', (event, config) => {
     })
 
     if (!hasError) {
+        if (config.openBuildPath) {
+            const handleOpenPathError = message => message && handleError({ message })
+            shell.openPath(FileConstants.BUILD_PATH).then(handleOpenPathError)
+        }
+
         mainWindow.webContents.send('compile-success')
     }
 })

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -29,6 +29,7 @@ const App = () => {
     const {
         baseComponentName,
         buildPath,
+        openBuildPath,
         baseComponentTemplate,
         componentTemplate,
         currentTab,
@@ -125,6 +126,7 @@ const App = () => {
             baseComponentName,
             baseComponentTemplate,
             buildPath,
+            openBuildPath,
             componentTemplate,
             fileExtension,
             hasSubfolder,
@@ -331,6 +333,18 @@ const App = () => {
                                 } Build Path`}
                             />
                         </FormField>
+                        {buildPath && (
+                            <FormField>
+                                <Checkbox
+                                    id="openBuildPathCheckbox"
+                                    checked={openBuildPath}
+                                    handleChange={createHandleToggle(
+                                        'openBuildPath'
+                                    )}
+                                    label="Open folder after building"
+                                />
+                            </FormField>
+                        )}
                         <FormField label="Actions">
                             <div className="buttons">
                                 <Button

--- a/src/renderer/utils/utilFunctions.js
+++ b/src/renderer/utils/utilFunctions.js
@@ -11,6 +11,7 @@ export const getInitialState = () => ({
     baseComponentName: 'App',
     baseComponentTemplate,
     buildPath: '',
+    openBuildPath: true,
     componentTemplate,
     currentTab: TabStates.PSEUDO,
     currentTemplateName: TemplateNames.BASE_COMPONENT,


### PR DESCRIPTION
**Feature from issue #11**

This Pull Request uses the `shell` module from `electron` to open the build folder after a successful compilation.

Also, it creates an option allowing users to decide whether they want to open it or not.

![Open Build Path Option](https://user-images.githubusercontent.com/39390862/95285508-59ef2380-0837-11eb-80e7-52bc5ecf19e4.png)
