### PR TITLE
Fix disable build button condition

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -160,7 +160,7 @@ const App = () => {
         isSelected ? 'is-selected' : 'is-outlined'
 
     const disableBuildButton =
-        !buildPath || !baseComponentName || !pseudo || !subfolderName
+        !buildPath || !baseComponentName || !pseudo || (hasSubfolder && !subfolderName)
 
     return (
         <div className="wrapper">


### PR DESCRIPTION
When the `Include subfolder` option is unchecked but the `Subfolder Name` field is empty, the user is unable to compile and build the components.

This Pull Request fixes it by adding the `hasSubfolder` state to the `disableBuildButton` condition, avoiding that undesired behavior.