### PR TITLE
Add: Open build-dir button

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { app, BrowserWindow, dialog, ipcMain } = require('electron')
+const { app, BrowserWindow, dialog, ipcMain, shell } = require('electron')
 const path = require('path')
 import { format as formatUrl } from 'url'
 const {
@@ -99,6 +99,10 @@ ipcMain.handle('open-file', async (event, isFile) => {
     })
 
     return response.filePaths[0]
+})
+
+ipcMain.handle('open-path', async (event, path) => {
+  return shell.openPath(path)
 })
 
 ipcMain.on('write-files', (event, config) => {

--- a/src/renderer/components/FormField.js
+++ b/src/renderer/components/FormField.js
@@ -1,10 +1,15 @@
 import React from 'react'
 
-const FormField = ({ children, label }) => {
+const FormField = ({ children, label, hasAddons = false }) => {
     return (
-        <div className="field pseudopia-field">
+        <div className={"field pseudopia-field " + (hasAddons ? 'has-addons' : '')}>
             {label && <label className="label">{label}</label>}
-            <div className="control">{children}</div>
+            {hasAddons
+                ? React.Children.map(children, child => (
+                    <div className="control">{child}</div>
+                ))
+                : <div className="control">{children}</div>
+            }
         </div>
     )
 }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -146,6 +146,10 @@ const App = () => {
         getInitialState()[currentTemplateName]
     )
 
+    const handleOpenPath = async () => {
+      await ipcRenderer.invoke('open-path', buildPath)
+    }
+
     const fileExtensionHandleChange = createHandleChange('fileExtension')
 
     const pseudoTabCurrent = currentTab === TabStates.PSEUDO
@@ -318,8 +322,12 @@ const App = () => {
                         </FormField>
                         <FormField label="Build Path (Required)">
                             {buildPath && (
-                                <FormField>
+                                <FormField hasAddons>
                                     <CodeBlock code={buildPath} />
+                                    <Button
+                                        handleClick={handleOpenPath}
+                                        text='Open'
+                                    />
                                 </FormField>
                             )}
                             <Button

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -75,6 +75,15 @@ pre {
     border: $pseudopia-border;
     border-radius: 8px;
 }
+.has-addons {
+  pre {
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+  }
+  .button {
+    padding: 28px 16px;
+  }
+}
 
 label.radio {
     padding: 1rem;


### PR DESCRIPTION
As disscused on #11, this PR adds a new button next the build path input, for quick access on the SO file browser.

<img src="https://user-images.githubusercontent.com/1274534/95667948-b3ef3200-0b32-11eb-93af-7e54a826a6fb.png" width="409" style="max-width:100%;">